### PR TITLE
spotpass: Add npfl to regex for 3DS

### DIFF
--- a/spotpass/read-boss-db-3ds.js
+++ b/spotpass/read-boss-db-3ds.js
@@ -1,7 +1,7 @@
 const fs = require('fs-extra');
 const apps = require('./ctr-boss-apps.json');
 
-const NPDL_REGEX = /npdl\.(?:cdn|c\.app)\.nintendowifi\.net\/p01\/nsa\/([A-z0-9]{16})\/(\w*)/g;
+const NPDL_REGEX = /(?:npdl|npfl)\.(?:cdn|c\.app)\.nintendowifi\.net\/p01\/(?:nsa|filelist)\/([A-z0-9]{16})\/(\w*)/g;
 
 const db = fs.readFileSync('./partitionA.bin', {
 	encoding: 'utf8'

--- a/spotpass/read-boss-db-3ds.js
+++ b/spotpass/read-boss-db-3ds.js
@@ -1,12 +1,12 @@
 const fs = require('fs-extra');
 const apps = require('./ctr-boss-apps.json');
 
-const NPDL_REGEX = /(?:npdl|npfl)\.(?:cdn|c\.app)\.nintendowifi\.net\/p01\/(?:nsa|filelist)\/([A-z0-9]{16})\/(\w*)/g;
+const REGEX = /(?:npdl|npfl)\.(?:cdn|c\.app)\.nintendowifi\.net\/p01\/(?:nsa|filelist)\/([A-z0-9]{16})\/(\w*)/g;
 
 const db = fs.readFileSync('./partitionA.bin', {
 	encoding: 'utf8'
 });
-const matches = [...db.matchAll(NPDL_REGEX)];
+const matches = [...db.matchAll(REGEX)];
 
 const appsLengthBefore = apps.length;
 let newTasks = 0;


### PR DESCRIPTION
A small number of tasks were discovered from npfl URLs that were not otherwise present. This pull adds npfl to the regex to ensure that those tasks are not missed.