### PR TITLE
spotpass: Make beginning of regex optional (3DS)

### DIFF
--- a/spotpass/read-boss-db-3ds.js
+++ b/spotpass/read-boss-db-3ds.js
@@ -1,7 +1,7 @@
 const fs = require('fs-extra');
 const apps = require('./ctr-boss-apps.json');
 
-const REGEX = /(?:npdl|npfl)\.(?:cdn|c\.app)\.nintendowifi\.net\/p01\/(?:nsa|filelist)\/([A-z0-9]{16})\/(\w*)/g;
+const REGEX = /(?:(?:npdl|npfl)\.(?:cdn|c\.app)\.nintendowifi\.net\/p01\/)?(?:nsa|filelist)\/([A-z0-9]{16})\/(\w*)/g;
 
 const db = fs.readFileSync('./partitionA.bin', {
 	encoding: 'utf8'

--- a/spotpass/read-boss-db-3ds.js
+++ b/spotpass/read-boss-db-3ds.js
@@ -1,7 +1,7 @@
 const fs = require('fs-extra');
 const apps = require('./ctr-boss-apps.json');
 
-const REGEX = /(?:(?:npdl|npfl)\.(?:cdn|c\.app)\.nintendowifi\.net\/p01\/)?(?:nsa|filelist)\/([A-z0-9]{16})\/(\w*)/g;
+const REGEX = /(?:nsa|filelist)\/([A-z0-9]{16})\/(\w*)/g;
 
 const db = fs.readFileSync('./partitionA.bin', {
 	encoding: 'utf8'


### PR DESCRIPTION
This is to make sure that data from partial URLs can still be parsed. So far we haven't encountered any, but that doesn't mean that they can't exist.