### PR TITLE
spotpass: Add task finder scripts

### DIFF
--- a/spotpass/3ds-task-finder.js
+++ b/spotpass/3ds-task-finder.js
@@ -37,7 +37,7 @@ async function findTask(task) {
 
 	if (!response.headers['content-type'] || !response.headers['content-type'].startsWith('text/plain')) {
 		return;
-	} else {
+	}
         	for (const app of apps) {
         		if (app.app_id === task.app_id) {
         			if (!app.tasks.includes(TASK_SEARCH)) {
@@ -48,7 +48,6 @@ async function findTask(task) {
         			}
         		}
         	}
-	}
 }
 
 async function find() {

--- a/spotpass/3ds-task-finder.js
+++ b/spotpass/3ds-task-finder.js
@@ -37,11 +37,9 @@ async function findTask(task) {
 
 	if (!response.headers['content-type'] || !response.headers['content-type'].startsWith('text/plain')) {
 		return;
-	}
-    else
+	} else {
         	for (const app of apps) {
         		if (app.app_id === task.app_id) {
-        			found = true;
         			if (!app.tasks.includes(TASK_SEARCH)) {
         				app.tasks.push(TASK_SEARCH);
 						fs.writeJSONSync('./ctr-boss-apps.json', apps, {
@@ -50,6 +48,7 @@ async function findTask(task) {
         			}
         		}
         	}
+	}
 }
 
 async function find() {

--- a/spotpass/3ds-task-finder.js
+++ b/spotpass/3ds-task-finder.js
@@ -20,7 +20,6 @@ async function main() {
 			let titleHasTask = false;
 			for (const appTask of app.tasks) {
 				if (task.toLowerCase() == appTask.toLowerCase()) {
-					console.log(`task ${task} already exists for app id ${app.app_id} (breaking)`);
 					titleHasTask = true;
 					break;
 				}
@@ -37,7 +36,7 @@ async function main() {
 			for (const country of COUNTRIES) {
 				for (const language of LANGUAGES) {
 					if (await taskExists(app, task, country, language)) {
-						console.log(`task ${task} found for app id ${app.app_id}`);
+						console.log(`Task ${task} found for app id ${app.app_id}`);
 						app.tasks.push(task);
 						await fs.writeJSONSync('./ctr-boss-apps.json', apps, {
 							spaces: '\t'
@@ -59,7 +58,6 @@ async function main() {
 async function taskExists(app, task, country, language) {
 	const response = await axios.get(`${NPFL_URL_BASE}/${app.app_id}/${task}?c=${country}&l=${language}`, {
 		validateStatus: () => {
-			console.log(`${app.app_id}, ${task}, ${country}, ${language}`)
 			return true;
 		},
 		httpsAgent

--- a/spotpass/3ds-task-finder.js
+++ b/spotpass/3ds-task-finder.js
@@ -44,6 +44,9 @@ async function findTask(task) {
         			found = true;
         			if (!app.tasks.includes(TASK_SEARCH)) {
         				app.tasks.push(TASK_SEARCH);
+						fs.writeJSONSync('./ctr-boss-apps.json', apps, {
+							spaces: '\t'
+						});
         			}
         		}
         	}
@@ -51,9 +54,6 @@ async function findTask(task) {
 
 async function find() {
 	await check3DS();
-	fs.writeJSONSync('./ctr-boss-apps.json', apps, {
-		spaces: '\t'
-	});
 	await database.close();
 }
 

--- a/spotpass/3ds-task-finder.js
+++ b/spotpass/3ds-task-finder.js
@@ -5,7 +5,7 @@ const database = require('./database');
 const apps = require('./ctr-boss-apps.json');
 
 const NPFL_URL_BASE = 'https://npfl.c.app.nintendowifi.net/p01/filelist';
-const TASK_SEARCH = 'FGONLYT'; // * For this example, I'm using the common FGONLYT task name, but there are other common task names that can be tested.
+const TASK_SEARCH = ['FGONLYT', 'news', 'data', 'TASK00', '0000001'] // * For this example, I'm using some common task names that are present in many games, but there are other ways this can be used, such as for matching tasks across different regions for a single game.
 
 const httpsAgent = new https.Agent({
 	rejectUnauthorized: false,
@@ -28,27 +28,30 @@ async function check3DS() {
 }
 
 async function findTask(task) {
-	const response = await axios.get(`${NPFL_URL_BASE}/${task.app_id}/${TASK_SEARCH}?c=${task.country}&l=${task.language}`, {
-		validateStatus: () => {
-			return true;
-		},
-		httpsAgent
-	});
+	for (const TASK of TASK_SEARCH) {
+		const response = await axios.get(`${NPFL_URL_BASE}/${task.app_id}/${TASK}?c=${task.country}&l=${task.language}`, {
+			validateStatus: () => {
+				return true;
+			},
+			httpsAgent
+		});
 
-	if (!response.headers['content-type'] || !response.headers['content-type'].startsWith('text/plain')) {
-		return;
+		if (!response.headers['content-type'] || !response.headers['content-type'].startsWith('text/plain')) {
+			return;
+		}
+	    for (const app of apps) {
+	    	if (app.app_id === task.app_id) {
+	    		if (!app.tasks.includes(TASK)) {
+	    			app.tasks.push(TASK);
+					fs.writeJSONSync('./ctr-boss-apps.json', apps, {
+						spaces: '\t'
+					});
+	    		}
+	    	}
+	    }
 	}
-        	for (const app of apps) {
-        		if (app.app_id === task.app_id) {
-        			if (!app.tasks.includes(TASK_SEARCH)) {
-        				app.tasks.push(TASK_SEARCH);
-						fs.writeJSONSync('./ctr-boss-apps.json', apps, {
-							spaces: '\t'
-						});
-        			}
-        		}
-        	}
 }
+
 
 async function find() {
 	await check3DS();

--- a/spotpass/3ds-task-finder.js
+++ b/spotpass/3ds-task-finder.js
@@ -32,7 +32,6 @@ async function main() {
 			// * Most BOSS apps are region-agnostic, but some require
 			// * specific combinations. Try every country/language
 			// * combination until a task is found
-			let taskFound = true;
 			check_locales: for (const country of COUNTRIES) {
 				for (const language of LANGUAGES) {
 					if (await taskExists(app, task, country, language)) {
@@ -41,8 +40,6 @@ async function main() {
 						await fs.writeJSONSync('./ctr-boss-apps.json', apps, {
 							spaces: '\t'
 						});
-
-						taskFound = true;
 						break check_locales;
 					}
 				}

--- a/spotpass/3ds-task-finder.js
+++ b/spotpass/3ds-task-finder.js
@@ -1,0 +1,61 @@
+const https = require('node:https');
+const axios = require('axios');
+const fs = require('fs-extra');
+const database = require('./database');
+const apps = require('./ctr-boss-apps.json');
+
+const NPFL_URL_BASE = 'https://npfl.c.app.nintendowifi.net/p01/filelist';
+const TASK_SEARCH = 'FGONLYT'; // * For this example, I'm using the common FGONLYT task name, but there are other common task names that can be tested.
+
+const httpsAgent = new https.Agent({
+	rejectUnauthorized: false,
+	cert: fs.readFileSync('./certs/wiiu-common.crt'), // * Hey, it works lol
+	key: fs.readFileSync('./certs/wiiu-common.key'),
+});
+
+async function check3DS() {
+	await database.connect();
+	let batch = await database.getNextBatch('ctr');
+
+	while (batch.length !== 0) {
+		await Promise.all(batch.map(async (task) => {
+			await findTask(task);
+			await database.rowProcessed(task.id);
+		}));
+
+		batch = await database.getNextBatch('ctr');
+	}
+}
+
+async function findTask(task) {
+	const response = await axios.get(`${NPFL_URL_BASE}/${task.app_id}/${TASK_SEARCH}?c=${task.country}&l=${task.language}`, {
+		validateStatus: () => {
+			return true;
+		},
+		httpsAgent
+	});
+
+	if (!response.headers['content-type'] || !response.headers['content-type'].startsWith('text/plain')) {
+		return;
+	}
+    else
+        	for (const app of apps) {
+        		if (app.app_id === task.app_id) {
+        			found = true;
+        			if (!app.tasks.includes(TASK_SEARCH)) {
+        				app.tasks.push(TASK_SEARCH);
+        			}
+        		}
+        	}
+}
+
+async function find() {
+	await check3DS();
+	fs.writeJSONSync('./ctr-boss-apps.json', apps, {
+		spaces: '\t'
+	});
+	await database.close();
+	await buildDatabase();
+}
+
+find();

--- a/spotpass/3ds-task-finder.js
+++ b/spotpass/3ds-task-finder.js
@@ -33,7 +33,7 @@ async function main() {
 			// * specific combinations. Try every country/language
 			// * combination until a task is found
 			let taskFound = true;
-			for (const country of COUNTRIES) {
+			check_locales: for (const country of COUNTRIES) {
 				for (const language of LANGUAGES) {
 					if (await taskExists(app, task, country, language)) {
 						console.log(`Task ${task} found for app id ${app.app_id}`);
@@ -43,14 +43,14 @@ async function main() {
 						});
 
 						taskFound = true;
-						break;
+						break check_locales;
 					}
 				}
 			}
 
-			if (taskFound) {
-				break;
-			}
+//			if (taskFound) {
+//				break;
+//			}
 		}
 	}
 }

--- a/spotpass/3ds-task-finder.js
+++ b/spotpass/3ds-task-finder.js
@@ -20,7 +20,6 @@ async function check3DS() {
 	while (batch.length !== 0) {
 		await Promise.all(batch.map(async (task) => {
 			await findTask(task);
-			await database.rowProcessed(task.id);
 		}));
 
 		batch = await database.getNextBatch('ctr');

--- a/spotpass/3ds-task-finder.js
+++ b/spotpass/3ds-task-finder.js
@@ -2,6 +2,7 @@ const https = require('node:https');
 const axios = require('axios');
 const fs = require('fs-extra');
 const database = require('./database');
+const buildDatabase = require('./build-database');
 const apps = require('./ctr-boss-apps.json');
 
 const NPFL_URL_BASE = 'https://npfl.c.app.nintendowifi.net/p01/filelist';
@@ -14,7 +15,6 @@ const httpsAgent = new https.Agent({
 });
 
 async function check3DS() {
-	await database.connect();
 	let batch = await database.getNextBatch('ctr');
 
 	while (batch.length !== 0) {
@@ -50,6 +50,7 @@ async function findTask(task) {
 }
 
 async function find() {
+	await database.connect();
 	await check3DS();
 	fs.writeJSONSync('./ctr-boss-apps.json', apps, {
 		spaces: '\t'

--- a/spotpass/3ds-task-finder.js
+++ b/spotpass/3ds-task-finder.js
@@ -20,6 +20,7 @@ async function check3DS() {
 	while (batch.length !== 0) {
 		await Promise.all(batch.map(async (task) => {
 			await findTask(task);
+			await database.rowProcessed(task.id);
 		}));
 
 		batch = await database.getNextBatch('ctr');

--- a/spotpass/3ds-task-finder.js
+++ b/spotpass/3ds-task-finder.js
@@ -47,10 +47,6 @@ async function main() {
 					}
 				}
 			}
-
-//			if (taskFound) {
-//				break;
-//			}
 		}
 	}
 }

--- a/spotpass/3ds-task-finder.js
+++ b/spotpass/3ds-task-finder.js
@@ -2,7 +2,6 @@ const https = require('node:https');
 const axios = require('axios');
 const fs = require('fs-extra');
 const database = require('./database');
-const buildDatabase = require('./build-database');
 const apps = require('./ctr-boss-apps.json');
 
 const NPFL_URL_BASE = 'https://npfl.c.app.nintendowifi.net/p01/filelist';
@@ -15,6 +14,7 @@ const httpsAgent = new https.Agent({
 });
 
 async function check3DS() {
+	await database.connect();
 	let batch = await database.getNextBatch('ctr');
 
 	while (batch.length !== 0) {
@@ -50,13 +50,11 @@ async function findTask(task) {
 }
 
 async function find() {
-	await database.connect();
 	await check3DS();
 	fs.writeJSONSync('./ctr-boss-apps.json', apps, {
 		spaces: '\t'
 	});
 	await database.close();
-	await buildDatabase();
 }
 
 find();

--- a/spotpass/build-database.js
+++ b/spotpass/build-database.js
@@ -18,7 +18,7 @@ const apps = [
 	})
 ];
 
-async function build() {
+async function buildDatabase() {
 	await database.connect();
 
 	await database.exec(`
@@ -62,4 +62,6 @@ async function build() {
 	await database.close();
 }
 
-build();
+buildDatabase();
+
+module.exports = buildDatabase;

--- a/spotpass/build-database.js
+++ b/spotpass/build-database.js
@@ -18,7 +18,7 @@ const apps = [
 	})
 ];
 
-async function buildDatabase() {
+async function build() {
 	await database.connect();
 
 	await database.exec(`
@@ -62,6 +62,5 @@ async function buildDatabase() {
 	await database.close();
 }
 
-buildDatabase();
+build();
 
-module.exports = buildDatabase;

--- a/spotpass/build-database.js
+++ b/spotpass/build-database.js
@@ -63,4 +63,3 @@ async function build() {
 }
 
 build();
-

--- a/spotpass/wiiu-task-finder.js
+++ b/spotpass/wiiu-task-finder.js
@@ -5,7 +5,7 @@ const { COUNTRIES, LANGUAGES } = require('./constants');
 const apps = require('./wup-boss-apps.json');
 
 const TASK_SHEET_URL_BASE = 'https://npts.app.nintendo.net/p01/tasksheet/1';
-const TASKS = ['olvinfo', 'news', 'param']; // * For this example, I'm using some task names that are present in Wii U games. Due to the limited information available about what BOSS tasks are on Wii U, these may or may not actually be common.
+const TASKS = ['news', 'param']; // * For this example, I'm using some task names that are present in Wii U games. Due to the limited information available about what BOSS tasks are on Wii U, these may or may not actually be common.
 
 const httpsAgent = new https.Agent({
 	rejectUnauthorized: false,

--- a/spotpass/wiiu-task-finder.js
+++ b/spotpass/wiiu-task-finder.js
@@ -32,7 +32,6 @@ async function main() {
 			// * Most BOSS apps are region-agnostic, but some require
 			// * specific combinations. Try every country/language
 			// * combination until a task is found
-			let taskFound = true;
 			check_locales: for (const country of COUNTRIES) {
 				for (const language of LANGUAGES) {
 					if (await taskExists(app, task, country, language)) {
@@ -41,8 +40,6 @@ async function main() {
 						await fs.writeJSONSync('./wup-boss-apps.json', apps, {
 							spaces: '\t'
 						});
-
-						taskFound = true;
 						break check_locales;
 					}
 				}

--- a/spotpass/wiiu-task-finder.js
+++ b/spotpass/wiiu-task-finder.js
@@ -1,0 +1,69 @@
+const https = require('node:https');
+const axios = require('axios');
+const fs = require('fs-extra');
+const { COUNTRIES, LANGUAGES } = require('./constants');
+const apps = require('./wup-boss-apps.json');
+
+const TASK_SHEET_URL_BASE = 'https://npts.app.nintendo.net/p01/tasksheet/1';
+const TASKS = ['olvinfo', 'news', 'param']; // * For this example, I'm using some task names that are present in Wii U games. Due to the limited information available about what BOSS tasks are on Wii U, these may or may not actually be common.
+
+const httpsAgent = new https.Agent({
+	rejectUnauthorized: false,
+	cert: fs.readFileSync('./certs/wiiu-common.crt'),
+	key: fs.readFileSync('./certs/wiiu-common.key'),
+});
+
+async function main() {
+	for (const app of apps) {
+		for (const task of TASKS) {
+			// * Skip the task if the app already has it
+			let titleHasTask = false;
+			for (const appTask of app.tasks) {
+				if (task.toLowerCase() == appTask.toLowerCase()) {
+					titleHasTask = true;
+					break;
+				}
+			}
+
+			if (titleHasTask) {
+				continue;
+			}
+
+			// * Most BOSS apps are region-agnostic, but some require
+			// * specific combinations. Try every country/language
+			// * combination until a task is found
+			let taskFound = true;
+			check_locales: for (const country of COUNTRIES) {
+				for (const language of LANGUAGES) {
+					if (await taskExists(app, task, country, language)) {
+						console.log(`Task ${task} found for app id ${app.app_id}`);
+						app.tasks.push(task);
+						await fs.writeJSONSync('./wup-boss-apps.json', apps, {
+							spaces: '\t'
+						});
+
+						taskFound = true;
+						break check_locales;
+					}
+				}
+			}
+		}
+	}
+}
+
+async function taskExists(app, task, country, language) {
+	const response = await axios.get(`${TASK_SHEET_URL_BASE}/${app.app_id}/${task}?c=${country}&l=${language}`, {
+		validateStatus: () => {
+			return true;
+		},
+		httpsAgent
+	});
+
+	if (!response.headers['content-type'] || !response.headers['content-type'].startsWith('application/xml')) {
+		return false;
+	}
+
+	return true;
+}
+
+main();


### PR DESCRIPTION
This is a script that automatically checks all present app IDs for a specified task name. This is useful for common names such as `FGONLYT` where many app IDs use it. This is essentially a mish-mash of parts of the `read-boss-db-3ds` and `scrape-3ds` scripts. It pings NPFL to check if the task exists under a certain app ID. If it's considered valid for that app ID, then it adds that task to the json. If invalid, it ignores and moves on.

**TODO**:

- [x] Everything Wii U (to be done once all of the below todos are finished)
- [x] Remove dependency on database and do things similarly to how `3ds-tasks-to-tid` does it
- [x] Write tasks one by one rather than all at once
- [x] Make it skip the NPFL process for apps that are already known to have the searched task.
- [x] Make it check existing tasks regardless of case

It's kinda sloppy right now, so feedback is greatly appreciated.